### PR TITLE
Add Docker support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM gcc
+
+ADD . /usr/src/statsd-tg/
+WORKDIR /usr/src/statsd-tg/
+
+RUN \
+  aclocal && \
+  autoheader && \
+  automake --add-missing --copy && \
+  autoconf && \
+  ./configure && \
+  make && \
+  make install
+
+ENTRYPOINT [ "statsd-tg" ]
+CMD [ "-h" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official GCC image, latest tag. More info at https://hub.docker.com/_/gcc/

Just adding files, setting working dir and running make instructions (except .po related, since required a ton of packages to install).

Build:

```
$ docker build -t statsd-tg .
```

Run:

```
$ docker run --rm -it statsd-tg [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it pataquets/statsd-tg [options...]
```
If run without arguments, ```-h``` is used, as per the CMD in the Dockerfile.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it.